### PR TITLE
Inject ILoggerFactory into Couchbase SDK

### DIFF
--- a/src/Couchbase.Extensions.DependencyInjection/Internal/ClusterProvider.cs
+++ b/src/Couchbase.Extensions.DependencyInjection/Internal/ClusterProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Couchbase.Configuration.Client;
 using Couchbase.Core;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Couchbase.Extensions.DependencyInjection.Internal
@@ -8,17 +9,23 @@ namespace Couchbase.Extensions.DependencyInjection.Internal
     internal class ClusterProvider : IClusterProvider
     {
         private readonly IOptions<CouchbaseClientDefinition> _options;
+        private readonly ILoggerFactory _loggerFactory;
         private ICluster _cluster;
         private bool _disposed = false;
 
-        public ClusterProvider(IOptions<CouchbaseClientDefinition> options)
+        public ClusterProvider(IOptions<CouchbaseClientDefinition> options, ILoggerFactory loggerFactory)
         {
             if (options == null)
             {
                 throw new ArgumentNullException(nameof(options));
             }
+            if (loggerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
 
             _options = options;
+            _loggerFactory = loggerFactory;
         }
 
         public virtual ICluster GetCluster()
@@ -43,7 +50,12 @@ namespace Couchbase.Extensions.DependencyInjection.Internal
         /// </summary>
         protected virtual ICluster CreateCluster(CouchbaseClientDefinition clientDefinition)
         {
-            return new Cluster(clientDefinition);
+            var configuration = new ClientConfiguration(clientDefinition)
+            {
+                LoggerFactory = _loggerFactory
+            };
+
+            return new Cluster(configuration);
         }
 
         public void Dispose()

--- a/tests/Couchbase.Extensions.DependencyInjection.IntegrationTests/BucketTests.cs
+++ b/tests/Couchbase.Extensions.DependencyInjection.IntegrationTests/BucketTests.cs
@@ -18,7 +18,9 @@ namespace Couchbase.Extensions.DependencyInjection.IntegrationTests
             var configuration = TestConfiguration.GetConfiguration();
 
             var services = new ServiceCollection();
-            services.AddCouchbase(configuration);
+            services
+                .AddLogging()
+                .AddCouchbase(configuration);
 
             var serviceProvider = services.BuildServiceProvider();
 
@@ -51,6 +53,7 @@ namespace Couchbase.Extensions.DependencyInjection.IntegrationTests
 
             var services = new ServiceCollection();
             services
+                .AddLogging()
                 .AddCouchbase(configuration)
                 .AddCouchbaseBucket<ITestBucketProvider>("travel-sample");
 

--- a/tests/Couchbase.Extensions.DependencyInjection.UnitTests/Internal/ClusterProviderTests.cs
+++ b/tests/Couchbase.Extensions.DependencyInjection.UnitTests/Internal/ClusterProviderTests.cs
@@ -2,6 +2,7 @@
 using Couchbase.Configuration.Client;
 using Couchbase.Core;
 using Couchbase.Extensions.DependencyInjection.Internal;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
@@ -19,9 +20,23 @@ namespace Couchbase.Extensions.DependencyInjection.UnitTests.Internal
         {
             // Act/Assert
 
-            var ex = Assert.Throws<ArgumentNullException>(() => new ClusterProvider(null));
+            var ex = Assert.Throws<ArgumentNullException>(() => new ClusterProvider(null, new LoggerFactory()));
 
             Assert.Equal("options", ex.ParamName);
+        }
+
+        [Fact]
+        public void ctor_NoLoggerFactory_Exception()
+        {
+            // Arrange
+
+            var options = new Mock<IOptions<CouchbaseClientDefinition>>();
+
+            // Act/Assert
+
+            var ex = Assert.Throws<ArgumentNullException>(() => new ClusterProvider(options.Object, null));
+
+            Assert.Equal("loggerFactory", ex.ParamName);
         }
 
         #endregion
@@ -34,8 +49,9 @@ namespace Couchbase.Extensions.DependencyInjection.UnitTests.Internal
             // Arrange
 
             var options = new Mock<IOptions<CouchbaseClientDefinition>>();
+            var loggerFactory = new LoggerFactory();
 
-            var provider = new ClusterProvider(options.Object);
+            var provider = new ClusterProvider(options.Object, loggerFactory);
             provider.Dispose();
 
             // Act/Assert
@@ -55,9 +71,11 @@ namespace Couchbase.Extensions.DependencyInjection.UnitTests.Internal
             var options = new Mock<IOptions<CouchbaseClientDefinition>>();
             options.SetupGet(m => m.Value).Returns(clientDefinition);
 
+            var loggerFactory = new LoggerFactory();
+
             var cluster = new Mock<ICluster>();
 
-            var provider = new Mock<ClusterProvider>(options.Object)
+            var provider = new Mock<ClusterProvider>(options.Object, loggerFactory)
             {
                 CallBase = true
             };
@@ -84,9 +102,11 @@ namespace Couchbase.Extensions.DependencyInjection.UnitTests.Internal
             var options = new Mock<IOptions<CouchbaseClientDefinition>>();
             options.SetupGet(m => m.Value).Returns(clientDefinition);
 
+            var loggerFactory = new LoggerFactory();
+
             var cluster = new Mock<ICluster>();
 
-            var provider = new Mock<ClusterProvider>(options.Object)
+            var provider = new Mock<ClusterProvider>(options.Object, loggerFactory)
             {
                 CallBase = true
             };
@@ -121,10 +141,12 @@ namespace Couchbase.Extensions.DependencyInjection.UnitTests.Internal
             var options = new Mock<IOptions<CouchbaseClientDefinition>>();
             options.SetupGet(m => m.Value).Returns(clientDefinition);
 
+            var loggerFactory = new LoggerFactory();
+
             var cluster = new Mock<ICluster>();
             cluster.Setup(m => m.Dispose());
 
-            var provider = new Mock<ClusterProvider>(options.Object)
+            var provider = new Mock<ClusterProvider>(options.Object, loggerFactory)
             {
                 CallBase = true
             };

--- a/tests/TestApp/appsettings.json
+++ b/tests/TestApp/appsettings.json
@@ -7,7 +7,8 @@
     "LogLevel": {
       "Default": "Debug",
       "System": "Information",
-      "Microsoft": "Information"
+      "Microsoft": "Information",
+      "Couchbase": "Debug"
     }
   },
   "Couchbase": {


### PR DESCRIPTION
Motivation
----------
Make use of the new ILoggerFactory support in Couchbase SDK 2.4.0.

Modifications
-------------
Inject LoggerFactory in ClientConfiguration when creating a cluster.

Results
-------
Couchbase now logs to the registered ILoggerFactory automatically,
filtered based on the Couchbase logger settings in your configuration.